### PR TITLE
Quick fixes to run `main.py` out-of-the-box

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ import pickle
 
 from utils import gurobi_lin
 import utils
-import visualize
+# import visualize
 # import test_suite
 from timeit import Timer as timer
 
@@ -28,7 +28,7 @@ parser.add_argument("--transformation", default=None, required=True, nargs='*', 
 parser.add_argument("--LB", default=None, required=True, nargs='*', type=float, help="List of the transformation lower bound(s).")
 parser.add_argument("--UB", default=None, required=True, nargs='*', type=float, help="List of the transformation upper bound(s).")
 parser.add_argument("--image_number", default=100, required=True, type=int, help="Number of images to obtain bounds for on MNIST")
-parser.add_argument("--save_bounds", required=True, help="Indicates whether or not to save the bounds.")
+parser.add_argument("--save_bounds", required=True, action='store_true', help="Indicates whether or not to save the bounds.")
 parser.add_argument("--bound_type", required=True, help="Indicates whether we are using 'linear' or 'pw_linear' bounds.")
 parser.add_argument("--dset", required=True, help="The dataset used, MNIST or CIFAR.")
 
@@ -619,7 +619,6 @@ def main(im_num, with_vis=False):
         im = Image(torch.tensor(fashion_dataset.data[im_num, :, :]/255., dtype=torch.float64), args.transformation, args.LB, args.UB)
     im.sample(args.sample_num, args.LB, args.UB)
 
-    import test_suite
     # start = time.time()
     # unsafe_lin_lb = test_suite.custom_lin_solver(im.image_samples, im.parameter_samples, 'lower', num_iterations=1000, lr=0.01)
     # unsafe_lin_ub = test_suite.custom_lin_solver(im.image_samples, im.parameter_samples, 'upper', num_iterations=10000, lr=0.5)


### PR DESCRIPTION
# Description
The current status of the `main.py` script does not run out-of-the-box. This PR proposes a few quick fixes so that first-time users can run the README command without issues:
- Comments out `visualize` module while @benbatten is working on resolution to #1 
- Parse `save_bounds` as a latch flag directly
- Comments out `test_suite` import since most of the code using `test_suite` is commented out.

Here are the errors showing:
**Error 1: No module named 'visualize'**
Also highlighted in #1 
```shell
$ python main.py
Traceback (most recent call last):
  File "/home/user/work/vnn/PWL-Geometric-Verification/main.py", line 19, in <module>
    import visualize

ModuleNotFoundError: No module named 'visualize'
```

**Error 2: --save_bounds: expected one argument**
```shell
$ python main.py --transformation rotate --LB 0 --UB 5 --image_number 1 --save_bounds --bound_type pw_linear --dset MNIST
usage: main.py [-h] --transformation [TRANSFORMATION ...] --LB [LB ...] --UB [UB ...] --image_number IMAGE_NUMBER --save_bounds SAVE_BOUNDS --bound_type BOUND_TYPE --dset DSET
               [--init_tasks INIT_TASKS] [--split_num SPLIT_NUM] [--use_gpu] [--sample_num SAMPLE_NUM] [--lipschitz_error LIPSCHITZ_ERROR]

main.py: error: argument --save_bounds: expected one argument
```

**Error 3: No module named 'test_suite'**
```shell
$ python main.py --transformation rotate --LB 0 --UB 5 --image_number 1 --save_bounds --bound_type pw_linear --dset MNIST --use_gpu
USING GPU
[5.0]
['rotate']
Converted upper bound to tensor([0.0873], dtype=torch.float64) radians
  0%|                                                                                                                                                                              | 0/1 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/home/user/work/vnn/PWL-Geometric-Verification/main.py", line 696, in <module>
    bounds = main(im, with_vis=with_vis)
  File "/home/user/work/vnn/PWL-Geometric-Verification/main.py", line 622, in main
    import test_suite
ModuleNotFoundError: No module named 'test_suite'
```

# Testing
:heavy_check_mark: Following the changes, I was able to the README command without any issues
**Command:** `python main.py --transformation rotate --LB 0 --UB 5 --image_number 1 --save_bounds --bound_type pw_linear --dset MNIST --use_gpu`

**Output:**
```shell
$ python main.py --transformation rotate --LB 0 --UB 5 --image_number 1 --save_bounds --bound_type pw_linear --dset MNIST --use_gpu
USING GPU
[5.0]
['rotate']
Converted upper bound to tensor([0.0873], dtype=torch.float64) radians
  0%|                                                                                                                                                                              | 0/1 [00:00<?, ?it/s]Restricted license - for non-production use only - expires 2025-11-24
INFO:gurobipy:Restricted license - for non-production use only - expires 2025-11-24
Time Taken: 21.92054510116577
Time Taken: 21.691070556640625
/home/user/work/vnn/PWL-Geometric-Verification/main.py:644: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
  unsafe_pw_bounds, pw_indicator = im.get_unsafe_pw_bound(torch.tensor(safe_lin_lb, dtype=torch.float64), torch.tensor(safe_lin_ub, dtype=torch.float64))
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [01:15<00:00, 75.90s/it]
done
```