### PR TITLE
Add project gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bounds/
+data/


### PR DESCRIPTION
# Description
To prevent inadvertent commits of data files, this PR proposes to add a `.gitignore` file to ignore the `bounds` and `data` folders from commits. 

# Testing
:heavy_check_mark: Tested a before/after scenario trying to create a new commit (see below).

## Before
The `bounds` and `data` folders appear as potential candidates to include in the commit:
```shell
$ git status
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        bounds/
        data/

nothing added to commit but untracked files present (use "git add" to track)
```

## After
The `data` and `bounds` folders are ignored, preventing accidental commits.
```shell
$ git status
On branch add-gitignore
Your branch is up to date with 'origin/add-gitignore'.

nothing to commit, working tree clean
```